### PR TITLE
Linux GCC

### DIFF
--- a/include/osgw/shader_program.hh
+++ b/include/osgw/shader_program.hh
@@ -9,6 +9,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include <array>
 #include <unordered_map>
 #include <functional>
 


### PR DESCRIPTION
Compilation for Linux using GCC is failing without this header, therefore included it.